### PR TITLE
Fix for file_show_real_filename to account for output of /usr/bin/which on RHEL6

### DIFF
--- a/lib/misc/file
+++ b/lib/misc/file
@@ -110,7 +110,7 @@ file_show_real_filename () {
 		*)
 			# AIX errors to stdout, ideally we'd use $? but which on Solaris doesn't exit() differently depending on result :(
 			# TODO maybe we should break it out with uname checks?
-			realfilename="`which \"\`basename \\\"${pattern}\\\"\`\" 2>&1 | egrep -v \"There is no |^no \"`"
+			realfilename="`which \"\`basename \\\"${pattern}\\\"\`\" 2>&1 | egrep -v \"There is no |^no |which: no \"`"
 			if [ -n "${realfilename}" ]
 			then
 				printf -- "${realfilename}\n"


### PR DESCRIPTION
With version 2.19 of the `which` utility, as available on RHEL6, the output for a non-existent file is:
> $ which foo
> /usr/bin/which: no foo in (/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin)

The egrep regex in `file_show_real_filename` doesn't account for this output, and thus it would put erroneous entries in the privileged file cache. This pull request fixes that. Tested successfully on RHEL6.